### PR TITLE
Fix stylesheet asset pipelining

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,5 @@
  */
 
 @import 'bootstrap';
+
+@import "/\*";


### PR DESCRIPTION
* Add the equivalent of require_tree in scss (that thing was removed in b3dd717 when bumping bootstrap to bootstrap 4)

Originally we had 
```scss
*= require_tree .
*= require_self
```

which was removed, so stylesheets for views in app/assets/stylesheets/[View].scss are not loaded