### PR TITLE
Add travis fast_finish option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - COMMAND="rake traceroute FAIL_ON_ERROR=1"
 
 matrix:
+  fast_finish: true
   allow_failures:
     - env: COMMAND="brakeman"
     - env: COMMAND="scss-lint app/assets/stylesheets"


### PR DESCRIPTION
https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing

> Now, the build result will be determined as soon as all the required jobs finish, based on these results, while the rest of the `allow_failures` jobs continue to run.