### PR TITLE
Redirect access denied to either login or home page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
 
   def access_denied(exception)
     store_location_for :user, request.path
-    redirect_to user_signed_in? ? root_path : new_user_session_path,
-                alert: exception.message
+    redirect_to(user_signed_in? ? root_path : new_user_session_path,
+                alert: exception.message)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
+  rescue_from CanCan::AccessDenied, with: :access_denied
 
   protected
 
@@ -12,5 +13,11 @@ class ApplicationController < ActionController::Base
                      password_confirmation remember_me mc cell]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+  end
+
+  def access_denied(exception)
+    store_location_for :user, request.path
+    redirect_to user_signed_in? ? root_path : new_user_session_path,
+                alert: exception.message
   end
 end

--- a/spec/controllers/availabilities/places_controller_spec.rb
+++ b/spec/controllers/availabilities/places_controller_spec.rb
@@ -5,15 +5,13 @@ require 'rails_helper'
 RSpec.describe Availabilities::PlacesController, type: :controller do
   describe 'GET #index' do
     it 'denies access when unauthenticated' do
-      expect do
-        get :index
-      end.to raise_error(CanCan::AccessDenied)
+      get :index
+      should redirect_to(new_user_session_path)
     end
     it 'denies access to normal user' do
       sign_in create(:user)
-      expect do
-        get :index
-      end.to raise_error(CanCan::AccessDenied)
+      get :index
+      should redirect_to(root_path)
     end
     it 'renders for admin' do
       user = create(:user)

--- a/spec/controllers/duties/places_controller_spec.rb
+++ b/spec/controllers/duties/places_controller_spec.rb
@@ -5,16 +5,14 @@ require 'rails_helper'
 RSpec.describe Duties::PlacesController, type: :controller do
   describe 'GET #index' do
     it 'denies access when unauthenticated' do
-      expect do
-        get :index
-      end.to raise_error(CanCan::AccessDenied)
+      get :index
+      should redirect_to(new_user_session_path)
     end
 
     it 'denies access to normal user' do
       sign_in create(:user)
-      expect do
-        get :index
-      end.to raise_error(CanCan::AccessDenied)
+      get :index
+      should redirect_to(root_path)
     end
 
     it 'renders for admin' do

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -13,13 +13,15 @@ RSpec.describe SettingsController, type: :controller do
     context 'normal user' do
       it do
         sign_in create(:user)
-        expect { get :edit }.to raise_error(CanCan::AccessDenied)
+        get :edit
+        should redirect_to(root_path)
       end
     end
     context 'mc' do
       it do
         sign_in create(:user, mc: true)
-        expect { get :edit }.to raise_error(CanCan::AccessDenied)
+        get :edit
+        should redirect_to(root_path)
       end
     end
     context 'admin' do
@@ -43,17 +45,15 @@ RSpec.describe SettingsController, type: :controller do
     context 'normal user' do
       it do
         sign_in create(:user)
-        expect do
-          put :update, params: { setting: { mc_only: true } }
-        end.to raise_error(CanCan::AccessDenied)
+        put :update, params: { setting: { mc_only: true } }
+        should redirect_to(root_path)
       end
     end
     context 'mc' do
       it do
         sign_in create(:user, mc: true)
-        expect do
-          put :update, params: { setting: { mc_only: true } }
-        end.to raise_error(CanCan::AccessDenied)
+        put :update, params: { setting: { mc_only: true } }
+        should redirect_to(root_path)
       end
     end
     context 'admin' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,9 +23,8 @@ RSpec.describe UsersController, type: :controller do
     it 'denies access when normal user access another users page' do
       user = create(:user)
       sign_in user
-      expect do
-        get :edit, params: { id: create(:user).id }
-      end.to raise_error(CanCan::AccessDenied)
+      get :edit, params: { id: create(:user).id }
+      should redirect_to(root_path)
     end
     it 'provides access to admin' do
       user = create(:user)
@@ -74,13 +73,12 @@ RSpec.describe UsersController, type: :controller do
         user = create(:user)
         new_user = create(:user, password: '123456')
         sign_in user
-        expect do
-          get :update, params: { id: new_user.id, user: { password: '1234567',
-                                                          confirmation_password:
+        get :update, params: { id: new_user.id, user: { password: '1234567',
+                                                        confirmation_password:
                                                           '1234567',
-                                                          current_password:
+                                                        current_password:
                                                           '123456' } }
-        end.to raise_error(CanCan::AccessDenied)
+        should redirect_to(root_path)
       end
     end
     context 'admin' do
@@ -111,10 +109,9 @@ RSpec.describe UsersController, type: :controller do
     it 'denies access to normal user' do
       user = create(:user)
       sign_in user
-      expect do
-        put :update_roles, params: { id: user.id, user: { cell: 'technical',
-                                                          mc: 'false' } }
-      end.to raise_error(CanCan::AccessDenied)
+      put :update_roles, params: { id: user.id, user: { cell: 'technical',
+                                                        mc: 'false' } }
+      should redirect_to(root_path)
     end
     context 'admin' do
       before do


### PR DESCRIPTION
Fixes #228 

Redirects to login page for users who have not logged in, and to home page for users who have no access to the requested page.