### PR TITLE
Option to change name

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@ body {
 @import 'edit_profile';
 @import 'new_user';
 @import 'allocate_role';
+@import 'change_name';
 @import 'duties';
 @import 'availabilities';
 @import 'announcements';

--- a/app/assets/stylesheets/change_name.scss
+++ b/app/assets/stylesheets/change_name.scss
@@ -1,0 +1,64 @@
+.edit-name {
+    width: 100%;
+  
+    .container {
+      margin-top: 5%;
+      text-align: center;
+    }
+  
+    .field {
+      text-align: left;
+    }
+  
+    tr {
+      height: 40px;
+      text-align: left;
+    }
+  
+    th,
+    td {
+      width: 100%;
+    }
+  
+    th {
+      font-weight: normal;
+    }
+  
+    input {
+      border-bottom: 2px solid $yellow;
+      border-left: 0;
+      border-right: 0;
+      border-top: 0;
+      color: $grey;
+      margin-bottom: 20px;
+      padding-left: 0%;
+      width: 250px;
+    }
+  
+    input:focus {
+      outline: none;
+    }
+  
+    .actions input:hover {
+      background-color: $light-yellow;
+    }
+  
+    .actions input {
+      background-color: $yellow;
+      border: 2px solid $yellow;
+      border-radius: 50px;
+      box-shadow: inset 1px 1px 3px -1px $light-yellow;
+      color: $black;
+      height: 50px;
+      margin-bottom: 0;
+      margin-top: 5%;
+      text-align: center;
+      text-shadow: 0 -.8px 0 $black,
+                   0 1px 0 $transparent-white;
+      width: 50%;
+    }
+  
+    .box {
+      overflow: auto;
+    }
+  }

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -35,6 +35,7 @@
   .pos,
   .role,
   .change-pw,
+  .change-name,
   .del,
   .hours {
     text-align: center;
@@ -54,6 +55,7 @@
 
   .role,
   .change-pw,
+  .change-name,
   .del {
     font-size: 12px;
     padding-left: 5px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,11 +38,26 @@ class UsersController < ApplicationController
     end
   end
 
+  def change_name; end
+
+  def update_name
+    if @user.update name_params
+      redirect_to users_path, notice: 'Name sucessfuly updated!'
+    else
+      redirect_to users_path, alert: 'Name updating failed!'
+    end
+  end
+
+
   def destroy
     redirect_to users_path if @user.destroy
   end
 
   private
+
+  def name_params
+    params.require(:user).permit(:username)
+  end
 
   def user_params
     params.require(:user).permit(:password, :password_confirmation,

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,7 +11,7 @@ class Ability
     cannot :show_everyone, Availability
 
     can :manage, User, id: user.id
-    cannot %i[create destroy allocate_roles update_roles show_full], User
+    cannot %i[create destroy allocate_roles update_roles update_name show_full], User
     cannot :change_without_password, User
 
     cannot :manage, Setting

--- a/app/views/users/change_name.html.erb
+++ b/app/views/users/change_name.html.erb
@@ -1,0 +1,34 @@
+<h1>Change Name</h1>
+
+<div class="change-name">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-6 offset-md-3">
+        <div class="box">
+
+          <%= form_for @user, :url => { controller: 'users', action: 'update_name' } do |u| %>
+            <table>
+              <div class="field">
+                <tr>
+                  <th><%= u.label :current_username %></th>
+                  <td><%= @user.username %></td>
+                </tr>
+              </div>
+
+              <div class="field">
+                <tr>
+                  <th><%= u.label :new_username %></th>
+                  <td><%= u.text_field :username, placeholder: @user.username, autocomplete: "off", :required => true %></td>
+                </tr>
+              </div>
+            </table>
+
+            <div class="actions">
+              <%= u.submit "Change Name" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/change_name.html.erb
+++ b/app/views/users/change_name.html.erb
@@ -1,6 +1,6 @@
 <h1>Change Name</h1>
 
-<div class="change-name">
+<div class="edit-name">
   <div class="container">
     <div class="row">
       <div class="col-md-6 offset-md-3">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -29,6 +29,7 @@
             <% if can?(:show_full, User) %>
               <!-- <th>Edit Profile</th> -->
               <th class="role">Allocate Role</th>
+              <th class="change-name">Change Name</th>
               <th class="change-pw">Change Password</th>
               <th class="del">Delete</th>
             <% end %>
@@ -46,6 +47,7 @@
               <td class="pos"><%= p.mc ? "MC" : "Member" %></td>
               <% if can?(:show_full, User) %>
                 <td class="role"><%= link_to 'Allocate roles', allocate_roles_user_path(p) %></td>
+                <td class="change-name"><%= link_to 'Change name', change_name_user_path(p) %></td>
                 <td class="change-pw"><%= link_to 'Change password', edit_user_path(p) %></td>
                 <td class="del"><%= link_to 'Delete', user_path(p), method: :delete, data: { confirm: 'Are you sure?' } %></td>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,10 @@ Rails.application.routes.draw do
       get 'allocate_roles', to: 'users#allocate_roles', as: 'allocate_roles'
       patch 'allocate_roles', to: 'users#update_roles'
       put 'allocate_roles', to: 'users#update_roles'
+
+      get 'change_name', to: 'users#change_name', as: 'change_name'
+      patch 'change_name', to: 'users#update_name'
+      put 'change_name', to: 'users#update_name'
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -181,6 +181,63 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
+  describe 'PUT #update_name' do
+    it 'redirects when unauthenticated' do
+      put :update_name, params: { id: create(:user).id }
+      should redirect_to(new_user_session_path)
+    end
+    it 'denies access to normal user' do
+      user = create(:user)
+      sign_in user
+      put :update_name, params: { id: user.id, user: { username: 'Name'} }
+      should redirect_to(root_path)
+    end
+    context 'admin' do
+      before do
+        user = create(:user)
+        user.add_role(:admin)
+        sign_in user
+        @user = user
+      end
+      it 'changes name' do
+        old_name = @user.username
+        expect do
+          put :update_name, params: { id: @user.id, user: { username: 'Name' } }
+        end.to change {
+          User.find(@user.id).username
+        }.from(old_name).to('Name')
+        should redirect_to(users_path)
+        expect(flash['notice']).to eq('Name sucessfuly updated!')
+      end
+      it 'handles failure' do
+        allow(@user).to receive(:update).and_return(false)
+        allow(User).to receive(:find).and_return(@user)
+        put :update_name, params: { id: @user.id, user: { username: 'Name' } }
+        should redirect_to(users_path)
+        expect(flash['alert']).to eq('Name updating failed!')
+      end
+    end
+    context 'pre-existing name' do
+      before do
+        user = create(:user,)
+        user.add_role(:admin)
+        sign_in user
+        @user = user
+        user2 = create(:user, username: 'Duplicate')
+      end
+      it 'denies change to same name' do
+        old_name = @user.username
+        expect do
+          put :update_name, params: { id: @user.id, user: { username: 'Duplicate' } }
+        end.to_not change {
+          User.find(@user.id).username
+        }.from(old_name)
+        should redirect_to(users_path)
+        expect(flash['alert']).to eq('Name updating failed!')
+      end
+    end
+  end
+
   describe 'DELETE #destroy' do
     it 'redirects when unauthenticated' do
       delete :destroy, params: { id: create(:user).id }

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe UsersController, type: :routing do
         .to route_to('users#allocate_roles', id: '1')
     end
 
+    it 'routes to #change_name' do
+      expect(get: '/users/1/change_name')
+        .to route_to('users#change_name', id: '1')
+    end
+
     it 'routes to #edit' do
       expect(get: '/users/1/edit').to route_to('users#edit', id: '1')
     end


### PR DESCRIPTION
Closes #362 

Since only MC/Presidential should be able to change it, the permissions to access this is the same as the one for allocating roles.

Normal restrictions such as having to change to a unique username still applies.

---
![Index](https://user-images.githubusercontent.com/42194963/67137943-32dac300-f26f-11e9-88e5-f1a417631e00.png)
---
![Edit screen](https://user-images.githubusercontent.com/42194963/67137959-7d5c3f80-f26f-11e9-9773-824946fdfb8f.png)
