### PR TITLE
Prevent non-MC from grabbing more than 16 hours

### DIFF
--- a/app/helpers/duties_helper.rb
+++ b/app/helpers/duties_helper.rb
@@ -20,7 +20,12 @@ module DutiesHelper
                           .where(user_id: current_user.id,
                                  date: start_date..end_date,
                                  free: false, request_user_id: nil)
-    total_seconds = relevant_duties.map do |d|
+    
+    sum_hours(relevant_duties)
+  end
+                              
+  def sum_hours(duties)
+    total_seconds = duties.map do |d|      
       d.time_range.end_time - d.time_range.start_time
     end.sum
     total_hours = total_seconds / 3600

--- a/app/helpers/duties_helper.rb
+++ b/app/helpers/duties_helper.rb
@@ -20,12 +20,11 @@ module DutiesHelper
                           .where(user_id: current_user.id,
                                  date: start_date..end_date,
                                  free: false, request_user_id: nil)
-    
     sum_hours(relevant_duties)
   end
-                              
+
   def sum_hours(duties)
-    total_seconds = duties.map do |d|      
+    total_seconds = duties.map do |d|
       d.time_range.end_time - d.time_range.start_time
     end.sum
     total_hours = total_seconds / 3600

--- a/app/helpers/duties_helper.rb
+++ b/app/helpers/duties_helper.rb
@@ -15,10 +15,10 @@ module DutiesHelper
     end
   end
 
-  def current_user_hours
+  def current_user_hours(start_date, end_date)
     relevant_duties = Duty.includes(:time_range)
                           .where(user_id: current_user.id,
-                                 date: @start_date..@end_date,
+                                 date: start_date..end_date,
                                  free: false, request_user_id: nil)
     total_seconds = relevant_duties.map do |d|
       d.time_range.end_time - d.time_range.start_time

--- a/app/views/duties/index.html.erb
+++ b/app/views/duties/index.html.erb
@@ -25,8 +25,8 @@
         <% if can?(:update_default_duties, Duty) %>
           <%= link_to 'Update Default Duties', availabilities_places_path, class: "btn btn-large btn-light duty-table-button" %>
         <% end %>
-        <div class = "duty-hours<%= current_user_hours > 16 ? " duty-hours-exceed" : "" %>">
-            Your hours: <%= current_user_hours %>
+        <div class = "duty-hours<%= current_user_hours(@start_date, @end_date) > 16 ? " duty-hours-exceed" : "" %>">
+            Your hours: <%= current_user_hours(@start_date, @end_date) %>
         </div>
       </div>
 

--- a/spec/helpers/duties_helper_spec.rb
+++ b/spec/helpers/duties_helper_spec.rb
@@ -135,10 +135,10 @@ RSpec.describe DutiesHelper, type: :helper do
       user = create(:user)
       sign_in user
       duties = create_list(:duty, 10, user: user)
-      assign(:start_date, duties[0].date)
-      assign(:end_date, duties[9].date)
+      start_date = duties[0].date
+      end_date = duties[9].date
 
-      result = helper.current_user_hours
+      result = helper.current_user_hours(start_date, end_date)
       expect(result).to eq((duties[-1].time_range.end_time -
        duties[0].time_range.start_time) / 3600)
 

--- a/spec/helpers/duties_helper_spec.rb
+++ b/spec/helpers/duties_helper_spec.rb
@@ -147,13 +147,11 @@ RSpec.describe DutiesHelper, type: :helper do
     end
   end
 
-  describe '#sum_hours' do 
-    it 'calculate hours correctly' do 
+  describe '#sum_hours' do
+    it 'calculate hours correctly' do
       user = create(:user)
       sign_in user
       duties = create_list(:duty, 10, user: user)
-      start_date = duties[0].date
-      end_date = duties[9].date
 
       result = helper.sum_hours(duties)
       expect(result).to eq((duties[-1].time_range.end_time -

--- a/spec/helpers/duties_helper_spec.rb
+++ b/spec/helpers/duties_helper_spec.rb
@@ -146,4 +146,21 @@ RSpec.describe DutiesHelper, type: :helper do
       create_list(:duty, 14, user: user)
     end
   end
+
+  describe '#sum_hours' do 
+    it 'calculate hours correctly' do 
+      user = create(:user)
+      sign_in user
+      duties = create_list(:duty, 10, user: user)
+      start_date = duties[0].date
+      end_date = duties[9].date
+
+      result = helper.sum_hours(duties)
+      expect(result).to eq((duties[-1].time_range.end_time -
+       duties[0].time_range.start_time) / 3600)
+
+      # Hack to reset time_range
+      create_list(:duty, 14, user: user)
+    end
+  end
 end


### PR DESCRIPTION
Close #299 

It should check each week independently, but if one week has more than 16 hours, no duties will be grabbed at all.

I cannot check this from the browser, since for some reason there are hidden duties (when I dropped all duties for a member at a week, the total number of hours is non-zero). But the rspec works