### PR TITLE
Fix announcement timezone

### DIFF
--- a/app/helpers/announcements_helper.rb
+++ b/app/helpers/announcements_helper.rb
@@ -4,6 +4,6 @@ module AnnouncementsHelper
   DETAILS_LENGTH = 90
 
   def format_time(time)
-    time.localtime.strftime('%d %B %C%y, %I:%M %p')
+    time.in_time_zone.strftime('%d %B %C%y, %I:%M %p')
   end
 end

--- a/app/views/announcements/_show.html.erb
+++ b/app/views/announcements/_show.html.erb
@@ -11,7 +11,7 @@
         </div>
 
         <div class="modal-body">
-          <div class="date">Posted on <%= announcement.created_at.localtime.strftime("%d %B %C%y, %I:%M %p") %></div>
+          <div class="date">Posted on <%= announcement.created_at.in_time_zone.strftime("%d %B %C%y, %I:%M %p") %></div>
           <div class="content-modal"><%= announcement.details %></div>
         </div>
 

--- a/spec/helpers/announcements_helper_spec.rb
+++ b/spec/helpers/announcements_helper_spec.rb
@@ -14,8 +14,8 @@ require 'rails_helper'
 # end
 RSpec.describe AnnouncementsHelper, type: :helper do
   it 'format_time working sucessfully' do
-    expect('03 March 2018, 04:04 AM').to eq(format_time(Time.new(
-      2018, 3, 3, 4, 4, 0
-    ).in_time_zone))
+    expect(format_time(Time.new(
+      2018, 3, 3, 4, 4, 0, "+08:00"
+    ).in_time_zone)).to eq('03 March 2018, 04:04 AM')
   end
 end


### PR DESCRIPTION
Maybe closes #387, maybe

My hypothesis is that the localtime method uses the machine timezone, which is GMT in the server. 
- When I changed my computer's time, the announcement timestamp changes.
- When I changed the app's timezone (in application.rb), it is unresponsive

Thus, I changed it to in_time_zone.
- It reacts to the app's timezone
- It does not react to my laptop's timezone